### PR TITLE
Remove "." from state abbreviations in address line, and fix bug wher…

### DIFF
--- a/code/pre_process.py
+++ b/code/pre_process.py
@@ -83,6 +83,7 @@ def multipleReplace(text, wordDict):
     with the associated value, return the changed text
     """
     for key in wordDict:
+        text = text.replace(".","")
         text = text.replace(key, wordDict[key])
     return text
 
@@ -92,11 +93,11 @@ def uppercase(matchobj):
     return '{'+temp+'}'
 
 def capitalize(s):
-    return re.sub('^([a-z])|[\.|\?|\!|\:]\s*([a-z])|\s+([a-z])(?=\.)', uppercase, s)
+    return re.sub('^((?i)[a-z])|[\.|\?|\!|\:]\s*((?i)[a-z])|\s+((?i)[a-z])(?=\.)', uppercase, s)
 
 
 # Go Through Each Line and Fine and Replace Problems
-with open(new_file_name, 'a') as n_file:
+with open(new_file_name, 'w') as n_file:
         with open(filename) as f:
             for line in f:
                 if 'author =' in str.lower(line) or 'editor =' in str.lower(line) or 'author=' in str.lower(line) or 'editor=' in str.lower(line):


### PR DESCRIPTION
…e title uppercase did not get protected

Mote details:

Sentence case in the title line was only protected when the start of the sentence was lowercase, changed the regex to be case insensitive so that also correctly formatted uppercases get protected from the forced lowercasing in the bst script. 

Also changed file write mode to "w" instead of "a", though not that important.
