### PR TITLE
Update to work with Python 3.6 and above

### DIFF
--- a/code/pre_process.py
+++ b/code/pre_process.py
@@ -7,8 +7,11 @@ from sys import argv
 import re
 
 # Inputs
-filename = '/Users/johanneskarreth/Documents/Dropbox/Uni/1 - Papers/HSIGOs and CPAs/Paper/Mediation and Signing/JPR submission/Final/JPR style/references_old.bib'
-new_file_name = '/Users/johanneskarreth/Documents/Dropbox/Uni/1 - Papers/HSIGOs and CPAs/Paper/Mediation and Signing/JPR submission/Final/JPR style/references_new.bib'
+filename = raw_input("Original bib file: ")
+new_file_name = raw_input("New bib file: ")
+
+filename = '/Users/baobaozhang/Dropbox/jpr-bst-file/example_latex/bad_bib.bib'
+new_file_name = '/Users/baobaozhang/Dropbox/jpr-bst-file/example_latex/good_bib.bib'
 # States Dictionary
 states = {
         'AK': 'Alaska',

--- a/code/pre_process.py
+++ b/code/pre_process.py
@@ -7,11 +7,8 @@ from sys import argv
 import re
 
 # Inputs
-filename = raw_input("Original bib file: ")
-new_file_name = raw_input("New bib file: ")
-
-filename = '/Users/baobaozhang/Dropbox/jpr-bst-file/example_latex/bad_bib.bib'
-new_file_name = '/Users/baobaozhang/Dropbox/jpr-bst-file/example_latex/good_bib.bib'
+filename = '/Users/johanneskarreth/Documents/Dropbox/Uni/1 - Papers/HSIGOs and CPAs/Paper/Mediation and Signing/JPR submission/Final/JPR style/references_old.bib'
+new_file_name = '/Users/johanneskarreth/Documents/Dropbox/Uni/1 - Papers/HSIGOs and CPAs/Paper/Mediation and Signing/JPR submission/Final/JPR style/references_new.bib'
 # States Dictionary
 states = {
         'AK': 'Alaska',
@@ -93,7 +90,7 @@ def uppercase(matchobj):
     return '{'+temp+'}'
 
 def capitalize(s):
-    return re.sub('^((?i)[a-z])|[\.|\?|\!|\:]\s*((?i)[a-z])|\s+((?i)[a-z])(?=\.)', uppercase, s)
+    return re.sub('^((re.I)[a-z])|[\.|\?|\!|\:]\s*((re.I)[a-z])|\s+((re.I)[a-z])(?=\.)', uppercase, s)
 
 
 # Go Through Each Line and Fine and Replace Problems


### PR DESCRIPTION
After receiving an error using this script on Python 3.11, I found out about this change: https://stackoverflow.com/questions/72284064/regex-expressions-deprecation-warning.

I updated the script accordingly (replaced ?i with re.I) and was able to run it successfully.

(Thank you for this very helpful script BTW!)